### PR TITLE
add/modify test

### DIFF
--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -256,12 +256,35 @@ describe('docblock', () => {
       os.EOL +
       ' * ' +
       os.EOL +
+      ' * @format' +
+      os.EOL +
+      ' * ' +
+      os.EOL +
       ' * world' +
       os.EOL +
       ' */';
     expect(docblock.parseWithComments(code)).toEqual({
-      comments: 'hello' + os.EOL + os.EOL + 'world',
-      pragmas: {flow: 'yes'},
+      comments: 'hello' + os.EOL + 'world',
+      pragmas: {flow: 'yes', format: ''},
+    });
+  });
+
+  it('extracts comments from end of docblock', () => {
+    const code =
+      '/**' +
+      os.EOL +
+      ' * @flow yes' +
+      os.EOL +
+      ' * @format' +
+      os.EOL +
+      ' * ' +
+      os.EOL +
+      ' * hello world' +
+      os.EOL +
+      ' */';
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments: 'hello world',
+      pragmas: {flow: 'yes', format: ''},
     });
   });
 


### PR DESCRIPTION
Given the docblock:

```
/**
 * hello
 * @flow yes
 * 
 * @format
 * 
 * world
 */
```

I expect the result of `parseWithComments` to be:
```js
{
 comments: 'hello\nworld',
 pragmas: { flow: 'yes', format: '' }
}
``